### PR TITLE
fix wrong href

### DIFF
--- a/website/samples/presets/index.html
+++ b/website/samples/presets/index.html
@@ -192,7 +192,7 @@
                         <p class="card-text">Triangles preset demo</p>
                     </div>
                     <div class="card-footer text-right">
-                        <a class="btn btn-primary" href="stars" target="_blank">See demo</a>
+                        <a class="btn btn-primary" href="triangles" target="_blank">See demo</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Hey I just notice a wrong path while browsing the demos, sorry it's such a small PR but I hope it helps :)
<img width="640" alt="Screenshot 2021-10-17 at 12 24 49" src="https://user-images.githubusercontent.com/47406531/137625564-88b221c4-6d7f-4434-9924-9050146b54f8.png">

