### PR TITLE
Fix #5524 matchMedia memory leak

### DIFF
--- a/engine/src/Core/Utils/EventListeners.ts
+++ b/engine/src/Core/Utils/EventListeners.ts
@@ -88,7 +88,7 @@ export class EventListeners {
      */
     constructor(private readonly container: Container) {
         this._canPush = true;
-        
+
         this._touches = new Map<number, number>();
         this._mediaMatch = safeMatchMedia("(prefers-color-scheme: dark)");
         this._handlers = {

--- a/engine/src/Core/Utils/EventListeners.ts
+++ b/engine/src/Core/Utils/EventListeners.ts
@@ -80,6 +80,7 @@ export class EventListeners {
     private _resizeObserver?: ResizeObserver;
     private _resizeTimeout?: NodeJS.Timeout;
     private readonly _touches: Map<number, number>;
+    private readonly _mediaMatch?: MediaQueryList;
 
     /**
      * Events listener constructor
@@ -87,8 +88,9 @@ export class EventListeners {
      */
     constructor(private readonly container: Container) {
         this._canPush = true;
-
+        
         this._touches = new Map<number, number>();
+        this._mediaMatch = safeMatchMedia("(prefers-color-scheme: dark)");
         this._handlers = {
             mouseDown: (): void => this._mouseDown(),
             mouseLeave: (): void => this._mouseTouchFinish(),
@@ -296,7 +298,7 @@ export class EventListeners {
 
     private readonly _manageMediaMatch: (add: boolean) => void = add => {
         const handlers = this._handlers,
-            mediaMatch = safeMatchMedia("(prefers-color-scheme: dark)");
+            mediaMatch = this._mediaMatch;
 
         if (!mediaMatch) {
             return;


### PR DESCRIPTION
Fix [#5524](https://github.com/tsparticles/tsparticles/issues/5524) by holding a stable reference to the `MediaQueryList` that has event listeners attached