### PR TITLE
chore: remove deprecation warning for package that doesn't exist

### DIFF
--- a/engine/scripts/install.js
+++ b/engine/scripts/install.js
@@ -187,20 +187,6 @@ async function checkErrors() {
         }
 
         if (dependencies["svelte"]) {
-            if (dependencies["svelte-particles"]) {
-                console.error(
-                    "\x1b[31m%s\x1b[0m",
-                    "The package svelte-particles has been deprecated and is not supported anymore."
-                );
-                console.error("\x1b[31m%s\x1b[0m", "Please consider switching to @tsparticles/svelte package.");
-                console.error(
-                    "\x1b[31m%s\x1b[0m",
-                    "This error will be fixed once svelte-particles is removed from the package.json file."
-                );
-
-                throw new Error(svelteParticlesFoundError);
-            }
-
             if (!dependencies["@tsparticles/svelte"]) {
                 console.warn(
                     "\x1b[43m\x1b[30m%s\x1b[0m",

--- a/engine/scripts/install.js
+++ b/engine/scripts/install.js
@@ -8,7 +8,6 @@ async function checkErrors() {
         reactParticlesJsFoundError = "react-particles-js-found",
         reactParticlesFoundError = "react-particles-found",
         reactTsParticlesFoundError = "react-tsparticles-found",
-        svelteParticlesFoundError = "svelte-particles-found",
         vue2ParticlesFoundError = "vue2-particles-found",
         vue3ParticlesFoundError = "vue3-particles-found";
 
@@ -240,8 +239,7 @@ async function checkErrors() {
             error.message === reactTsParticlesFoundError ||
             error.message === angularParticlesFoundError ||
             error.message === vue2ParticlesFoundError ||
-            error.message === vue3ParticlesFoundError ||
-            error.message === svelteParticlesFoundError
+            error.message === vue3ParticlesFoundError
         ) {
             throw error;
         }


### PR DESCRIPTION
This condition is impossible to hit because the package doesn't exist: https://www.npmjs.com/package/svelte-particles

I left the next condition, but `@tsparticles/svelte` is stuck on Svelte 4, which makes it not able to be used. There's an open PR to fix it over in https://github.com/tsparticles/svelte

**Did you build the project before submitting the PR?**

- [x] Yes
- [ ] No
